### PR TITLE
Reverse index for ServiceMonitor to Prometheus

### DIFF
--- a/pkg/indexers/prometheus_index.go
+++ b/pkg/indexers/prometheus_index.go
@@ -1,0 +1,226 @@
+package indexers
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/appscode/go/arrays"
+	"github.com/appscode/kubed/pkg/util"
+	"github.com/appscode/log"
+	"github.com/appscode/pat"
+	"github.com/blevesearch/bleve"
+	prom "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type PrometheusIndexer interface {
+	Add(prom *prom.Prometheus) error
+	Delete(prom *prom.Prometheus) error
+	Update(old, new *prom.Prometheus) error
+	AddServiceMonitor(*prom.ServiceMonitor, []*prom.Prometheus) error
+	DeleteServiceMonitor(monitor *prom.ServiceMonitor) error
+	Key(meta metav1.ObjectMeta) []byte
+	ServeHTTP(w http.ResponseWriter, req *http.Request)
+}
+
+var _ PrometheusIndexer = &PrometheusIndexerImpl{}
+
+type PrometheusIndexerImpl struct {
+	kubeClient clientset.Interface
+	promClient prom.MonitoringV1alpha1Interface
+	index      bleve.Index
+}
+
+func (ri *PrometheusIndexerImpl) Add(prom *prom.Prometheus) error {
+	log.Infof("New Prometheus: %v", prom.Name)
+	log.V(5).Infof("Prometheus details: %v", prom)
+
+	svcMonitors, err := ri.serviceMonitorsForPrometheus(prom)
+	if err != nil {
+		return err
+	}
+
+	for _, monitors := range svcMonitors.Items {
+		key := ri.Key(monitors.ObjectMeta)
+		ri.insert(key, prom)
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) Delete(prom *prom.Prometheus) error {
+	svc, err := ri.serviceMonitorsForPrometheus(prom)
+	if err != nil {
+		return err
+	}
+
+	for _, monitors := range svc.Items {
+		key := ri.Key(monitors.ObjectMeta)
+		ri.remove(key, prom)
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) Update(old, new *prom.Prometheus) error {
+	if !reflect.DeepEqual(old.Spec.ServiceMonitorSelector, new.Spec.ServiceMonitorSelector) {
+		// Only update if selector changes
+		err := ri.Delete(old)
+		if err != nil {
+			return err
+		}
+		err = ri.Add(new)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) AddServiceMonitor(m *prom.ServiceMonitor, prom []*prom.Prometheus) error {
+	key := ri.Key(m.ObjectMeta)
+	for _, prometheus := range prom {
+		selector, err := metav1.LabelSelectorAsSelector(prometheus.Spec.ServiceMonitorSelector)
+		if err != nil {
+			continue
+		}
+		if labels.SelectorFromSet(labels.Set(m.Labels)).String() != selector.String() {
+			continue
+		}
+
+		ri.insert(key, prometheus)
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) DeleteServiceMonitor(m *prom.ServiceMonitor) error {
+	return ri.index.DeleteInternal(ri.Key(m.ObjectMeta))
+}
+
+func (ri *PrometheusIndexerImpl) insert(key []byte, prometheus *prom.Prometheus) error {
+	raw, err := ri.index.GetInternal(key)
+	if err != nil || len(raw) == 0 {
+		data := prom.PrometheusList{Items: []*prom.Prometheus{prometheus}}
+		raw, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		err = ri.index.SetInternal(key, raw)
+		if err != nil {
+			return err
+		}
+	} else {
+		var data prom.PrometheusList
+		err := json.Unmarshal(raw, &data)
+		if err != nil {
+			return err
+		}
+
+		if found, _ := arrays.Contains(data.Items, prometheus); !found {
+			data.Items = append(data.Items, prometheus)
+			raw, err := json.Marshal(data)
+			if err != nil {
+				return err
+			}
+			err = ri.index.SetInternal(key, raw)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) remove(key []byte, prometheus *prom.Prometheus) error {
+	raw, err := ri.index.GetInternal(key)
+	if err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		var data prom.PrometheusList
+		err := json.Unmarshal(raw, &data)
+		if err != nil {
+			return err
+		}
+		var prometheuss []*prom.Prometheus
+		for i, valueSvc := range data.Items {
+			if ri.equal(prometheus, valueSvc) {
+				prometheuss = append(data.Items[:i], data.Items[i+1:]...)
+				break
+			}
+		}
+
+		if len(prometheuss) == 0 {
+			// Remove unnecessary index
+			err = ri.index.DeleteInternal(key)
+			if err != nil {
+				return err
+			}
+		} else {
+			raw, err := json.Marshal(prom.PrometheusList{Items: prometheuss})
+			if err != nil {
+				return err
+			}
+			err = ri.index.SetInternal(key, raw)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (ri *PrometheusIndexerImpl) serviceMonitorsForPrometheus(prometheus *prom.Prometheus) (*prom.ServiceMonitorList, error) {
+	selector, err := metav1.LabelSelectorAsSelector(prometheus.Spec.ServiceMonitorSelector)
+	if err != nil {
+		return &prom.ServiceMonitorList{}, err
+	}
+
+	pods, err := ri.promClient.ServiceMonitors(metav1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if val, ok := pods.(*prom.ServiceMonitorList); ok {
+		return val, nil
+	}
+	return &prom.ServiceMonitorList{}, err
+}
+
+func (ri *PrometheusIndexerImpl) equal(a, b *prom.Prometheus) bool {
+	if a.Name == b.Name && a.Namespace == b.Namespace {
+		return true
+	}
+	return false
+}
+
+func (ri *PrometheusIndexerImpl) Key(meta metav1.ObjectMeta) []byte {
+	return []byte(util.GetGroupVersionKind(&prom.ServiceMonitor{}).String() + "/" + meta.Namespace + "/" + meta.Name)
+}
+
+func (ri *PrometheusIndexerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	log.Infoln("Request received at", req.URL.Path)
+	params, found := pat.FromContext(req.Context())
+	if !found {
+		http.Error(w, "Missing parameters", http.StatusBadRequest)
+		return
+	}
+
+	namespace, name := params.Get(":namespace"), params.Get(":name")
+	if len(namespace) > 0 && len(name) > 0 {
+		key := ri.Key(v1.ObjectMeta{Name: name, Namespace: namespace})
+		if val, err := ri.index.GetInternal(key); err == nil && len(val) > 0 {
+			if err := json.NewEncoder(w).Encode(json.RawMessage(val)); err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("x-content-type-options", "nosniff")
+				return
+			} else {
+				http.Error(w, "Server error"+err.Error(), http.StatusInternalServerError)
+			}
+		} else {
+			http.NotFound(w, req)
+		}
+		return
+	}
+	http.Error(w, "Bad Request", http.StatusBadRequest)
+}

--- a/pkg/indexers/reverse_index.go
+++ b/pkg/indexers/reverse_index.go
@@ -12,25 +12,32 @@ import (
 type ReverseIndexer struct {
 	// kubeClient to access kube api server
 	kubeClient clientset.Interface
+	promClient prom.MonitoringV1alpha1Interface
 	index      bleve.Index
 
 	Service        ServiceIndexer
 	ServiceMonitor ServiceMonitorIndexer
+	Prometheus     PrometheusIndexer
 }
 
-func NewReverseIndexer(cl clientset.Interface, dst string) (*ReverseIndexer, error) {
+func NewReverseIndexer(cl clientset.Interface, pm prom.MonitoringV1alpha1Interface, dst string) (*ReverseIndexer, error) {
 	index, err := ensureIndex(filepath.Join(dst, "reverse.indexer"), "indexer")
 	if err != nil {
 		return nil, err
 	}
 	ri := ReverseIndexer{
 		kubeClient: cl,
+		promClient: pm,
 		index:      index,
 	}
 	ri.Service = &ServiceIndexerImpl{kubeClient: cl, index: index}
 	if util.IsPreferredAPIResource(cl, prom.TPRGroup+"/"+prom.TPRVersion, prom.TPRServiceMonitorsKind) {
 		// Add Indexer only if Server support this resource
 		ri.ServiceMonitor = &ServiceMonitorIndexerImpl{kubeClient: cl, index: index}
+	}
+	if util.IsPreferredAPIResource(cl, prom.TPRGroup+"/"+prom.TPRVersion, prom.TPRPrometheusesKind) {
+		// Add Indexer only if Server support this resource
+		ri.Prometheus = &PrometheusIndexerImpl{kubeClient: cl, promClient: pm, index: index}
 	}
 	return &ri, nil
 }

--- a/pkg/indexers/servicemonitor_index.go
+++ b/pkg/indexers/servicemonitor_index.go
@@ -13,9 +13,9 @@ import (
 	prom "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/labels"
 )
 
 type ServiceMonitorIndexer interface {
@@ -36,8 +36,8 @@ type ServiceMonitorIndexerImpl struct {
 }
 
 func (ri *ServiceMonitorIndexerImpl) Add(svcMonitor *prom.ServiceMonitor) error {
-	log.Infof("New service: %v", svcMonitor.Name)
-	log.V(5).Infof("Service details: %v", svcMonitor)
+	log.Infof("New svcMonitor: %v", svcMonitor.Name)
+	log.V(5).Infof("svcMonitor details: %v", svcMonitor)
 
 	svc, err := ri.serviceForServiceMonitors(svcMonitor)
 	if err != nil {
@@ -185,11 +185,11 @@ func (ri *ServiceMonitorIndexerImpl) serviceForServiceMonitors(svcMonitor *prom.
 
 	list := &apiv1.ServiceList{Items: make([]apiv1.Service, 0)}
 	for _, ns := range svcMonitor.Spec.NamespaceSelector.MatchNames {
-		pods, err := ri.kubeClient.CoreV1().Services(ns).List(metav1.ListOptions{
+		svc, err := ri.kubeClient.CoreV1().Services(ns).List(metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})
 		if err == nil {
-			list.Items = append(list.Items, pods.Items...)
+			list.Items = append(list.Items, svc.Items...)
 		}
 	}
 	return list, nil

--- a/pkg/operator/prom_prometheus.go
+++ b/pkg/operator/prom_prometheus.go
@@ -47,6 +47,12 @@ func (op *Operator) WatchPrometheuss() {
 							log.Errorln(err)
 						}
 					}
+
+					if op.Opt.EnableReverseIndex {
+						if err := op.ReverseIndex.Prometheus.Add(res); err != nil {
+							log.Errorln(err)
+						}
+					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -59,6 +65,13 @@ func (op *Operator) WatchPrometheuss() {
 							log.Errorln(err)
 						}
 					}
+
+					if op.Opt.EnableReverseIndex {
+						if err := op.ReverseIndex.Prometheus.Delete(res); err != nil {
+							log.Errorln(err)
+						}
+					}
+
 					if op.TrashCan != nil {
 						op.TrashCan.Delete(res.TypeMeta, res.ObjectMeta, obj)
 					}
@@ -81,6 +94,13 @@ func (op *Operator) WatchPrometheuss() {
 				if op.Opt.EnableSearchIndex {
 					op.SearchIndex.HandleUpdate(old, new)
 				}
+
+				if op.Opt.EnableReverseIndex {
+					if err := op.ReverseIndex.Prometheus.Update(oldRes, newRes); err != nil {
+						log.Errorln(err)
+					}
+				}
+
 				if op.TrashCan != nil && op.Config.TrashCan.HandleUpdate {
 					if !reflect.DeepEqual(oldRes.Labels, newRes.Labels) ||
 						!reflect.DeepEqual(oldRes.Annotations, newRes.Annotations) ||

--- a/pkg/operator/prom_servicemonitor.go
+++ b/pkg/operator/prom_servicemonitor.go
@@ -52,6 +52,16 @@ func (op *Operator) WatchServiceMonitors() {
 						if err := op.ReverseIndex.ServiceMonitor.Add(res); err != nil {
 							log.Errorln(err)
 						}
+						if op.ReverseIndex.Prometheus != nil {
+							proms, err := op.PromClient.Prometheuses(apiv1.NamespaceAll).List(metav1.ListOptions{})
+							if err != nil {
+								log.Errorln(err)
+								return
+							}
+							if promList, ok := proms.(*prom.PrometheusList); ok {
+								op.ReverseIndex.Prometheus.AddServiceMonitor(res, promList.Items)
+							}
+						}
 					}
 				}
 			},
@@ -72,6 +82,9 @@ func (op *Operator) WatchServiceMonitors() {
 					if op.Opt.EnableReverseIndex {
 						if err := op.ReverseIndex.ServiceMonitor.Delete(res); err != nil {
 							log.Errorln(err)
+						}
+						if op.ReverseIndex.Prometheus != nil {
+							op.ReverseIndex.Prometheus.DeleteServiceMonitor(res)
 						}
 					}
 				}

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	searchlight "github.com/appscode/searchlight/api"
 	stash "github.com/appscode/stash/api"
 	voyager "github.com/appscode/voyager/api"
+	prom "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	kubedb "github.com/k8sdb/apimachinery/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -142,6 +143,10 @@ func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
 		return kubedb.V1alpha1SchemeGroupVersion.WithKind("DormantDatabase")
 	case *stash.Restic:
 		return stash.V1alpha1SchemeGroupVersion.WithKind("Restic")
+	case *prom.ServiceMonitor:
+		return schema.GroupVersionKind{Group: prom.TPRGroup, Version: prom.TPRVersion, Kind: prom.TPRServiceMonitorsKind}
+	case *prom.Prometheus:
+		return schema.GroupVersionKind{Group: prom.TPRGroup, Version: prom.TPRVersion, Kind: prom.TPRPrometheusesKind}
 	default:
 		return schema.GroupVersionKind{}
 	}
@@ -323,6 +328,14 @@ func AssignTypeKind(v interface{}) error {
 	case *stash.Restic:
 		u.APIVersion = stash.V1alpha1SchemeGroupVersion.String()
 		u.Kind = "Restic"
+		return nil
+	case *prom.ServiceMonitor:
+		u.APIVersion = schema.GroupVersion{Group: prom.TPRGroup, Version: prom.TPRVersion}.String()
+		u.Kind = prom.TPRServiceMonitorsKind
+		return nil
+	case *prom.Prometheus:
+		u.APIVersion = schema.GroupVersion{Group: prom.TPRGroup, Version: prom.TPRVersion}.String()
+		u.Kind = prom.TPRPrometheusesKind
 		return nil
 	}
 	return errors.New("Unknown api object type")


### PR DESCRIPTION
```
// http://localhost:8081/apis/monitoring.coreos.com/v1alpha1/namespaces/default/servicemonitors/example-app/prometheuses

{
  "metadata": {
    
  },
  "items": [
    {
      "kind": "Prometheus",
      "apiVersion": "monitoring.coreos.com/v1alpha1",
      "metadata": {
        "name": "prometheus",
        "namespace": "default",
        "selfLink": "/apis/monitoring.coreos.com/v1alpha1/namespaces/default/prometheuses/prometheus",
        "uid": "d8b91861-6d39-11e7-b25b-0800276cdbf9",
        "resourceVersion": "3412",
        "creationTimestamp": "2017-07-20T10:54:47Z"
      },
      "spec": {
        "serviceMonitorSelector": {
          "matchLabels": {
            "team": "frontend"
          }
        },
        "version": "v1.7.0",
        "alerting": {
          "alertmanagers": null
        },
        "resources": {
          "requests": {
            "memory": "400Mi"
          }
        }
      }
    }
  ]
}
```