### PR TITLE
Sync secret Kind

### DIFF
--- a/pkg/syncer/secret.go
+++ b/pkg/syncer/secret.go
@@ -137,6 +137,7 @@ func (s *ConfigSyncer) upsertSecret(k8sClient kubernetes.Interface, src *core.Se
 
 		obj.Data = src.Data
 		obj.Labels = labels.Merge(src.Labels, s.syncerLabels(src.Name, src.Namespace, s.clusterName))
+		obj.Kind = src.Kind
 
 		ref := core.ObjectReference{
 			APIVersion:      src.APIVersion,


### PR DESCRIPTION
Seceret's `Kind` field is lost when the new secret is created. This PR fixes it.