### PR TITLE
Permit specifying compute resources for the kubed container.

### DIFF
--- a/chart/kubed/README.md
+++ b/chart/kubed/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the Kubed chart and the
 | `affinity`                       | Affinity rules for pod assignment                                 | `{}`               |
 | `nodeSelector`                   | Node labels for pod assignment                                    | `{}`               |
 | `tolerations`                    | Tolerations used pod assignment                                   | `{}`               |
+| `resources`                      | Compute resources for the kubed container                         | `{}`               |
 | `rbac.create`                    | If `true`, create and use RBAC resources                          | `true`             |
 | `serviceAccount.create`          | If `true`, create a new service account                           | `true`             |
 | `serviceAccount.name`            | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `` |

--- a/chart/kubed/templates/deployment.yaml
+++ b/chart/kubed/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
         - --enable-analytics={{ .Values.enableAnalytics }}
         ports:
         - containerPort: 8443
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: config
           mountPath: /srv/kubed

--- a/chart/kubed/values.yaml
+++ b/chart/kubed/values.yaml
@@ -38,6 +38,11 @@ tolerations: {}
 ##
 affinity: {}
 
+## Compute resource for the kubed container
+## https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
+##
+resources: {}
+
 ## Install Default RBAC roles and bindings
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
Signed-off-by: Raymond Fallon <rfallon@360incentives.com>

Resolves https://github.com/appscode/kubed/issues/315

Permit specifying compute resources for the kubed container. We use this to mitigate concerns with excessive memory consumption described in https://github.com/appscode/kubed/issues/304