### PR TITLE
Adds option to allocate/use pvc with helm installation

### DIFF
--- a/chart/kubed/README.md
+++ b/chart/kubed/README.md
@@ -54,6 +54,12 @@ The following table lists the configurable parameters of the Kubed chart and the
 | `criticalAddon`                  | If true, installs kubed operator as critical addon                | `false`            |
 | `logLevel`                       | Log level for kubed                                               | `3`                |
 | `affinity`                       | Affinity rules for pod assignment                                 | `{}`               |
+| `persistence.enabled`            | Use persistent volume to store data                               | `false`            |
+| `persistence.size`               | Size of persistent volume claim                                   | `10Gi`             |
+| `persistence.existingClaim`      | Use an existing PVC to persist data                               | `nil`              |
+| `persistence.storageClassName`   | Type of persistent volume claim                                   | `nil`              |
+| `persistence.accessModes`        | Persistence access modes                                          | `[ReadWriteOnce]`  |
+| `persistence.subPath`            | Mount a sub dir of the persistent volume                          | `nil`              |
 | `nodeSelector`                   | Node labels for pod assignment                                    | `{}`               |
 | `tolerations`                    | Tolerations used pod assignment                                   | `{}`               |
 | `resources`                      | Compute resources for the kubed container                         | `{}`               |

--- a/chart/kubed/templates/deployment.yaml
+++ b/chart/kubed/templates/deployment.yaml
@@ -67,6 +67,13 @@ spec:
           mountPath: /tmp
         - mountPath: /var/serving-cert
           name: serving-cert
+      {{- if .Values.persistence.enabled }}
+        - name: storage
+          mountPath: "/var/lib/kubed"
+        {{- if .Values.persistence.subPath }}
+            subPath: {{ .Values.persistence.subPath }}
+        {{- end }}
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -77,6 +84,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ template "kubed.fullname" . }}-apiserver-cert
+      {{- if .Values.persistence.enabled }}
+      - name: storage
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "kubed.fullname" . }}{{- end }}
+      {{- end }}
 {{- if or .Values.tolerations (and .Values.criticalAddon (eq .Release.Namespace "kube-system")) }}
       tolerations:
 {{- if .Values.tolerations }}

--- a/chart/kubed/templates/pvc.yaml
+++ b/chart/kubed/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "kubed.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "kubed.name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  {{- with .Values.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+{{- end -}}
+

--- a/chart/kubed/values.yaml
+++ b/chart/kubed/values.yaml
@@ -43,6 +43,20 @@ affinity: {}
 ##
 resources: {}
 
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  # subPath: ""
+  # existingClaim:
+
+
 ## Install Default RBAC roles and bindings
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
Signed-off-by: Derek Heldt-Werle <derek.heldt-werle@viasat.com>


This PR provides a baked in option to allocate a PVC during the helm installation. With this, attaching a persistent volume for use with the recycle bin (or potentially the snapshots when using the local backend option) can be done without having to allocate any resources separately. 