### PR TITLE
Use absolute path as aliases for reference docs

### DIFF
--- a/docs/reference/kubed.md
+++ b/docs/reference/kubed.md
@@ -11,7 +11,7 @@ product_name: kubed
 menu_name: product_kubed_0.10.0
 section_menu_id: reference
 aliases:
-  - products/kubed/0.10.0/reference/
+  - /products/kubed/0.10.0/reference/
 
 ---
 ## kubed

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -47,7 +47,7 @@ menu_name: product_kubed_{{ .Version }}
 section_menu_id: reference
 {{- if .RootCmd }}
 aliases:
-  - products/kubed/{{ .Version }}/reference/
+  - /products/kubed/{{ .Version }}/reference/
 {{ end }}
 ---
 `))


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>