### PR TITLE
Implementation of  #355. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:jessie-20190506
+COPY kubed /usr/bin/kubed
+ENTRYPOINT ["/usr/bin/kubed"]
+

--- a/apis/kubed/v1alpha1/openapi_generated.go
+++ b/apis/kubed/v1alpha1/openapi_generated.go
@@ -321,6 +321,12 @@ func schema_kubed_apis_kubed_v1alpha1_ClusterConfig(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"configSourceNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"snapshotter": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/appscode/kubed/apis/kubed/v1alpha1.SnapshotSpec"),

--- a/apis/kubed/v1alpha1/types.go
+++ b/apis/kubed/v1alpha1/types.go
@@ -27,6 +27,7 @@ type ClusterConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
 	ClusterName        string              `json:"clusterName,omitempty"`
+	ConfigSourceNamespace	string         `json:"configSourceNamespace,omitempty"`
 	Snapshotter        *SnapshotSpec       `json:"snapshotter,omitempty"`
 	RecycleBin         *RecycleBinSpec     `json:"recycleBin,omitempty"`
 	EventForwarder     *EventForwarderSpec `json:"eventForwarder,omitempty"`

--- a/chart/kubed/templates/secret.yaml
+++ b/chart/kubed/templates/secret.yaml
@@ -1,6 +1,9 @@
 {{ define "kubed.config" }}
 clusterName: "{{ .Values.config.clusterName }}"
 enableConfigSyncer: {{ .Values.config.enableConfigSyncer }}
+{{- if .Values.config.configSourceNamespace }}
+configSourceNamespace: {{ .Values.config.configSourceNamespace }}
+{{- end }}
 notifierSecretName: {{ template "kubed.fullname" . }}-notifier
 {{- if .Values.config.enableEventForwarder }}
 eventForwarder:

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -80,6 +80,8 @@ func (c *OperatorConfig) New() (*Operator, error) {
 	indexDir := filepath.Join(c.ScratchDir, "indices")
 	op.Indexer = resource_indexer.NewIndexer(indexDir)
 
+	op.Configure()
+
 	op.watcher = &fsnotify.Watcher{
 		WatchDir: filepath.Dir(c.ConfigPath),
 		Reload:   op.Configure,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -185,11 +185,28 @@ func (op *Operator) setupNetworkInformers() {
 }
 
 func (op *Operator) setupConfigInformers() {
-	configMapInformer := op.kubeInformerFactory.Core().V1().ConfigMaps().Informer()
+//	configMapInformer := op.kubeInformerFactory.Core().V1().ConfigMaps().Informer()
+	configMapInformer := op.kubeInformerFactory.InformerFor(&core.ConfigMap{}, func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+		return core_informers.NewFilteredConfigMapInformer(
+			client,
+			"commonconfig",
+			resyncPeriod,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			func(options *metav1.ListOptions) {},
+		)
+	})
 	op.addEventHandlers(configMapInformer, core.SchemeGroupVersion.WithKind("ConfigMap"))
 	configMapInformer.AddEventHandler(op.configSyncer.ConfigMapHandler())
 
-	secretInformer := op.kubeInformerFactory.Core().V1().Secrets().Informer()
+	secretInformer := op.kubeInformerFactory.InformerFor(&core.Secret{}, func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+		return core_informers.NewFilteredSecretInformer(
+			client,
+			"commonconfig",
+			resyncPeriod,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			func(options *metav1.ListOptions) {},
+		)
+	})
 	op.addEventHandlers(secretInformer, core.SchemeGroupVersion.WithKind("Secret"))
 	secretInformer.AddEventHandler(op.configSyncer.SecretHandler())
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -185,11 +185,10 @@ func (op *Operator) setupNetworkInformers() {
 }
 
 func (op *Operator) setupConfigInformers() {
-//	configMapInformer := op.kubeInformerFactory.Core().V1().ConfigMaps().Informer()
 	configMapInformer := op.kubeInformerFactory.InformerFor(&core.ConfigMap{}, func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		return core_informers.NewFilteredConfigMapInformer(
 			client,
-			"commonconfig",
+			op.clusterConfig.ConfigSourceNamespace,
 			resyncPeriod,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {},
@@ -201,7 +200,7 @@ func (op *Operator) setupConfigInformers() {
 	secretInformer := op.kubeInformerFactory.InformerFor(&core.Secret{}, func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		return core_informers.NewFilteredSecretInformer(
 			client,
-			"commonconfig",
+			op.clusterConfig.ConfigSourceNamespace,
 			resyncPeriod,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {},


### PR DESCRIPTION
With this change, a new optional configuration setting called "configSourceNamespace" is created. 
If specified, then only the configmaps and secrets in the namespace defined in the option and are annotated will be replicated. 
On the other hand, if the option is not specified then configmaps and secrets will be replicated as long as they are annotated as usual. 
