### PR TITLE
Change old "extensions/v1beta1" to new "apps/v1"

### DIFF
--- a/chart/kubed/Chart.yaml
+++ b/chart/kubed/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 description: 'Kubed by AppsCode - Kubernetes daemon'
 name: kubed
 version: v0.11.0
+kubeVersion: ">=1.9.0"
 appVersion: v0.11.0
 home: https://github.com/appscode/kubed
 icon: https://cdn.appscode.com/images/icon/kubed.png

--- a/chart/kubed/templates/deployment.yaml
+++ b/chart/kubed/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubed.fullname" . }}


### PR DESCRIPTION
Some old API versions were deprecated in k8s 1.16: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

This PR allows to use `kubed` on Kubernetes 1.16 and higher
Fixing #369 