### PR TITLE
Custom securityContext in template

### DIFF
--- a/charts/kubed/templates/deployment.yaml
+++ b/charts/kubed/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           defaultMode: 420
           secretName: {{ template "kubed.fullname" . }}-apiserver-cert
       securityContext:
-        fsGroup: 65535
+{{ toYaml .Values.securityContext | indent 8 }}
 {{- if or .Values.tolerations (and .Values.criticalAddon (eq .Release.Namespace "kube-system")) }}
       tolerations:
 {{- if .Values.tolerations }}

--- a/charts/kubed/values.yaml
+++ b/charts/kubed/values.yaml
@@ -48,6 +48,9 @@ affinity: {}
 ##
 resources: {}
 
+securityContext:
+  fsGroup: 65535
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
Hello, we currently use kubed in a cluster that has very strict security policies enabled. One of them requires us to specify that each k8s workload has to run as non root, not only in the docker image itself, but also in the security context of the workload. Specifically, we need to add the following key:

```
securityContext:
    runAsNonRoot: true
``` 

I have followed the same approach currently used for pod resources, which is converting the values dictionary directly into yaml in the template, using `toYaml`. This would let us modify `securityContext` to fit our requirement, while the default value is the same as it currently is hardcoded in the template.

Please let me know if the pull request is incomplete.