### PR TITLE
Don't panic when syncing into namespace fails

### DIFF
--- a/pkg/syncer/resourcehandlers.go
+++ b/pkg/syncer/resourcehandlers.go
@@ -22,7 +22,6 @@ import (
 	"github.com/appscode/go/log"
 
 	core "k8s.io/api/core/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -149,7 +148,9 @@ func (s *nsSyncer) OnAdd(obj interface{}) {
 	defer s.lock.RUnlock()
 
 	if res, ok := obj.(*core.Namespace); ok {
-		utilruntime.Must(s.SyncIntoNamespace(res.Name))
+		if err := s.SyncIntoNamespace(res.Name); err != nil {
+			log.Errorln(err)
+		}
 	}
 }
 
@@ -160,7 +161,9 @@ func (s *nsSyncer) OnUpdate(oldObj, newObj interface{}) {
 	old := oldObj.(*core.Namespace)
 	nu := newObj.(*core.Namespace)
 	if !reflect.DeepEqual(old.Labels, nu.Labels) {
-		utilruntime.Must(s.SyncIntoNamespace(nu.Name))
+		if err := s.SyncIntoNamespace(nu.Name); err != nil {
+			log.Errorln(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Sync failure may happen for various reasons, for example namespace may get terminated. This should not cause
failure of kubed.

Closes: #382